### PR TITLE
cleans up pem files post npm install

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var del = require('del');
 var gulp = require('gulp');
 var gutil = require('gulp-util');
 var webpack = require('webpack');
@@ -13,4 +14,9 @@ function bundle(callback){
   });
 }
 
+function postInstall(callback){
+  del('node_modules/**/*.pem', callback);
+}
+
+gulp.task(postInstall);
 gulp.task('default', gulp.parallel(bundle));

--- a/package.json
+++ b/package.json
@@ -17,12 +17,14 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "gulp",
+    "postinstall": "gulp postInstall",
     "serve": "webpack-dev-server"
   },
   "dependencies": {},
   "devDependencies": {
     "babel-core": "^5.3.3",
     "babel-loader": "^5.0.0",
+    "del": "^1.2.0",
     "gulp": "git://github.com/gulpjs/gulp#4.0",
     "gulp-util": "^3.0.4",
     "lodash": "^3.8.0",


### PR DESCRIPTION
#### What's this PR do?

Removes all .pem files inside the node_models folder after npm install is run.
#### Where should the reviewer start? / How should this be manually tested?

Pull down the branch, rm -rf your node_modules if it's there already.  Run an npm install, then load the unpacked extension into chrome, marveling at the lack of red error text.
#### Any background context you want to provide?

Nope
#### What are the relevant tickets?

closes #4 
