### PR TITLE
add pr template removal function to page action button

### DIFF
--- a/src/fillPullBody.js
+++ b/src/fillPullBody.js
@@ -4,11 +4,13 @@ chrome.runtime.onMessage.addListener(function(request){
   const prBodyElement = document.getElementById('pull_request_body');
   if(request.fillPR && prBodyElement){
     chrome.storage.sync.get('prTemplate', function({ prTemplate }){
-      if(prBodyElement && !prBodyElement.value.includes(prTemplate)){
+      if(!prBodyElement.value.includes(prTemplate)){
         if(prBodyElement.value){
           prBodyElement.value += '\n';
         }
         prBodyElement.value = prBodyElement.value + prTemplate;
+      } else if(prBodyElement.value.includes(prTemplate)){
+        prBodyElement.value = prBodyElement.value.replace(prTemplate, '');
       }
     });
   }

--- a/src/fillPullBody.js
+++ b/src/fillPullBody.js
@@ -9,7 +9,7 @@ chrome.runtime.onMessage.addListener(function(request){
           prBodyElement.value += '\n';
         }
         prBodyElement.value = prBodyElement.value + prTemplate;
-      } else if(prBodyElement.value.includes(prTemplate)){
+      } else {
         prBodyElement.value = prBodyElement.value.replace(prTemplate, '');
       }
     });


### PR DESCRIPTION
#### What's this PR do?

Adds the ability to remove an unaltered PR template by clicking the page action button a second time.
#### Where should the reviewer start?

fillPullBody.js contains all of the changes.
#### How should this be manually tested?

Pull down and rebuild. Try adding and removing PR template from the PR field. Note: if there existing text when the template is inserted, the extra /n is not removed upon removing the template. These /n will build up over successive additions/removals. I don't think there is a good way to predict whether the /n should be removed or not, so I am leaving that behavior alone.
#### Any background context you want to provide?

N/A
#### What are the relevant tickets?

closes #19 
