### PR TITLE
adds lint task to gulp, .jscsrc, and fixes a few linting errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,5 +15,8 @@
   },
   "globals": {
     "chrome": true
-  }
+  },
+  "plugins": [
+    "react"
+  ]
 }

--- a/.jscsrc
+++ b/.jscsrc
@@ -7,7 +7,6 @@
       "for",
       "while"
     ],
-    "disallowSpaceBeforeKeywords": null,
     "disallowSpacesInFunction": {
       "beforeOpeningCurlyBrace": true,
       "beforeOpeningRoundBrace": true

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,30 @@
+{
+    "preset": "node-style-guide",
+    "esnext": true,
+    "esprima": "esprima-fb",
+    "disallowSpaceAfterKeywords": [
+      "if",
+      "for",
+      "while"
+    ],
+    "disallowSpaceBeforeKeywords": null,
+    "disallowSpacesInFunction": {
+      "beforeOpeningCurlyBrace": true,
+      "beforeOpeningRoundBrace": true
+    },
+    "maximumLineLength": null,
+    "requireSpaceAfterKeywords": [
+      "else",
+      "try",
+      "catch",
+      "do",
+      "switch"
+    ],
+    "requireSpaceBeforeBlockStatements": null,
+    "requireSpaceBeforeKeywords": [
+      "else",
+      "catch"
+    ],
+    "requireSpacesInFunction": null,
+    "requireTrailingComma": null
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,11 +2,15 @@
 
 var del = require('del');
 var gulp = require('gulp');
+var jscs = require('gulp-jscs');
 var gutil = require('gulp-util');
 var webpack = require('webpack');
+var eslint = require('gulp-eslint');
+var stylish = require('gulp-jscs-stylish');
 
 var webpackConfig = require('./webpack.config');
 
+function noop() {}
 function bundle(callback){
   webpack(webpackConfig, function(err){
     gutil.log('Webpack bundle complete!');
@@ -14,9 +18,20 @@ function bundle(callback){
   });
 }
 
+function lint(){
+  return gulp.src('src/**/*.js')
+    .pipe(eslint())
+    .pipe(eslint.format())
+    .pipe(jscs())
+    .on('error', noop)
+    .pipe(stylish());
+}
+
 function postInstall(callback){
   del('node_modules/**/*.pem', callback);
 }
 
+gulp.task(lint);
 gulp.task(postInstall);
 gulp.task('default', gulp.parallel(bundle));
+

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,11 +6,9 @@ var jscs = require('gulp-jscs');
 var gutil = require('gulp-util');
 var webpack = require('webpack');
 var eslint = require('gulp-eslint');
-var stylish = require('gulp-jscs-stylish');
 
 var webpackConfig = require('./webpack.config');
 
-function noop() {}
 function bundle(callback){
   webpack(webpackConfig, function(err){
     gutil.log('Webpack bundle complete!');
@@ -23,8 +21,7 @@ function lint(){
     .pipe(eslint())
     .pipe(eslint.format())
     .pipe(jscs())
-    .on('error', noop)
-    .pipe(stylish());
+    .pipe(eslint.failAfterError());
 }
 
 function postInstall(callback){

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "index.js"
   ],
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "gulp lint",
     "build": "gulp",
     "postinstall": "gulp postInstall",
     "serve": "webpack-dev-server",
@@ -28,7 +28,13 @@
     "babel-core": "^5.3.3",
     "babel-loader": "^5.0.0",
     "del": "^1.2.0",
+    "eslint": "^0.21.2",
+    "eslint-plugin-react": "^2.3.0",
+    "esprima-fb": "^15001.1.0-dev-harmony-fb",
     "gulp": "git://github.com/gulpjs/gulp#4.0",
+    "gulp-eslint": "^0.12.0",
+    "gulp-jscs": "^1.6.0",
+    "gulp-jscs-stylish": "^1.1.0",
     "gulp-util": "^3.0.4",
     "lodash": "^3.8.0",
     "react": "^0.13.3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "gulp": "git://github.com/gulpjs/gulp#4.0",
     "gulp-eslint": "^0.12.0",
     "gulp-jscs": "^1.6.0",
-    "gulp-jscs-stylish": "^1.1.0",
     "gulp-util": "^3.0.4",
     "lodash": "^3.8.0",
     "react": "^0.13.3",

--- a/src/getContent.js
+++ b/src/getContent.js
@@ -4,10 +4,10 @@ const rest = require('rest');
 
 function getContent(){
   chrome.storage.sync.get('templateUrl', function(res){
-      return rest(res.templateUrl)
-        .then(function(response){
-          chrome.storage.sync.set({ 'prTemplate': response.entity });
-        });
+    return rest(res.templateUrl)
+      .then(function(response){
+        chrome.storage.sync.set({ prTemplate: response.entity });
+      });
   });
 }
 


### PR DESCRIPTION
#### What's this PR do?

Adds a .jscsrc file that should match all of our rules, fixes some eslint errors, and makes "npm test" run eslint and jscs
#### Where should the reviewer start?

The gulpfile should give a broad overview of what's happening. While the specific rules are in the .jscsrc and .eslintrc
#### How should this be manually tested?

Pull down the branch, screw up any file inside the src directory with a combination of weird spacing and some unused variable names, save it and then run "npm test" in your terminal.
#### Any background context you want to provide?

eslint doesn't play nice with React without the plugin I've included.  There's an alternate(undocumented) way of adding every variable that's "unused" into an ignore in the eslint but this would have a lot of upkeep(plus I couldn't seem to get it to work).

Additionally JSCS has sixteen million rules, so as we notice things that should be jscs errors we'll want to update this.
#### What are the relevant tickets?

closes #10
#### Screenshots (if appropriate)

![linting](https://cloud.githubusercontent.com/assets/2651110/7735827/9d00d558-fef4-11e4-81d0-928b33951839.png)
