### PR TITLE
connect load and cancel buttons, enable/disable buttons, replace existing template in PRs with new template on save

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -2,13 +2,15 @@
 
 const getContent = require('./getContent');
 
-chrome.storage.sync.get(['templateUrl', 'autoFill'], function({templateUrl, autoFill}){
-  if(!templateUrl){
-    chrome.storage.sync.set({
-      templateUrl: 'http://cdn.rawgit.com/iceddev/getting-started/master/pr-template.md'
-    }, getContent);
-  } else {
-    getContent();
+chrome.storage.sync.get(['templateUrl', 'prTemplate', 'autoFill'], function({templateUrl, prTemplate, autoFill}){
+  if(!prTemplate){
+    if(!templateUrl){
+      chrome.storage.sync.set({
+        templateUrl: 'http://cdn.rawgit.com/iceddev/getting-started/master/pr-template.md'
+      }, getContent);
+    } else {
+      getContent();
+    }
   }
   if(autoFill === undefined){
     chrome.storage.sync.set({ autoFill: false });

--- a/src/components/template-tab.js
+++ b/src/components/template-tab.js
@@ -1,8 +1,8 @@
 'use strict';
 
+const _ = require('lodash');
+const rest = require('rest');
 const React = require('react');
-
-const getContent = require('../getContent');
 
 const Button = require('../primed/button');
 
@@ -11,32 +11,92 @@ class TemplateTab extends React.Component {
     super(...args);
     this.state = {
       templateUrl: '',
-      deltaUrl: ''
+      deltaUrl: '',
+      prTemplate: '',
+      deltaTemplate: '',
+      disableCancel: true,
+      disableSubmit: true
     };
+    this.handleTemplateChange = this.handleTemplateChange.bind(this);
+    this.handleLoad = this.handleLoad.bind(this);
     this.handleUrlChange = this.handleUrlChange.bind(this);
+    this.handleCancel = this.handleCancel.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
   }
   componentDidMount(){
-    chrome.storage.sync.get('templateUrl', (res)=>{
+    chrome.storage.sync.get(['templateUrl', 'prTemplate'], (res)=>{
       this.setState({
         templateUrl: res.templateUrl,
-        deltaUrl: res.templateUrl
+        deltaUrl: res.templateUrl,
+        prTemplate: res.prTemplate,
+        deltaTemplate: res.prTemplate
       });
     });
   }
+  handleTemplateChange(){
+    this.setState({
+      deltaTemplate: event.target.value,
+      disableCancel: false,
+      disableSubmit: false
+    });
+  }
+  handleLoad(){
+    rest(this.state.deltaUrl)
+      .then((response)=>{
+        this.setState({
+          deltaTemplate: response.entity
+        });
+        if(response.entity === this.state.prTemplate){
+          this.setState({ disableSubmit: true });
+          if(this.state.deltaUrl === this.state.templateUrl){
+            this.setState({ disableCancel: true });
+          }
+        } else {
+          this.setState({ disableSubmit: false });
+        }
+      });
+  }
   handleUrlChange(){
-    this.setState({ deltaUrl: event.target.value });
+    this.setState({
+      deltaUrl: event.target.value
+    });
+    if(event.target.value !== this.state.templateUrl){
+      this.setState({
+        disableCancel: false
+      });
+    }
+  }
+  handleCancel(){
+    this.setState({
+      deltaUrl: this.state.templateUrl,
+      deltaTemplate: this.state.prTemplate,
+      disableCancel: true,
+      disableSubmit: true
+    });
   }
   handleSubmit(){
+    const { deltaUrl, deltaTemplate, prTemplate } = this.state;
+
     this.setState({
-      templateUrl: this.state.deltaUrl
+      templateUrl: deltaUrl,
+      prTemplate: deltaTemplate,
+      disableCancel: true,
+      disableSubmit: true
     });
 
-    chrome.storage.sync.set({ templateUrl: this.state.deltaUrl});
-    getContent();
+    chrome.storage.sync.set({
+      prTemplate: deltaTemplate,
+      templateUrl: deltaUrl
+    }, function(){
+      chrome.tabs.query({ url: 'https://github.com/*/*' }, function(tabs){
+        _.forEach(tabs, function(tab){
+          chrome.tabs.sendMessage(tab.id, { replaceTemplate: prTemplate });
+        });
+      });
+    });
   }
   render(){
-    const { deltaUrl } = this.state;
+    const { deltaUrl, deltaTemplate } = this.state;
 
     return (
       <div className="four-fifths column">
@@ -45,7 +105,7 @@ class TemplateTab extends React.Component {
             <label htmlFor='template'>Template:</label>
           </dt>
           <dd>
-            <textarea id='template' />
+            <textarea id='template' onChange={this.handleTemplateChange} value={deltaTemplate}/>
           </dd>
         </dl>
         <dl className='form'>
@@ -56,7 +116,7 @@ class TemplateTab extends React.Component {
             <div className='input-group'>
               <input className='long' id='url' type='text' name='url' onChange={this.handleUrlChange} value={deltaUrl} />
               <span className='input-group-button'>
-                <Button>
+                <Button onClick={this.handleLoad}>
                   Load <span className='octicon octicon-cloud-download'></span>
                 </Button>
               </span>
@@ -64,8 +124,8 @@ class TemplateTab extends React.Component {
           </dd>
         </dl>
         <div className="form-actions">
-          <Button primary onClick={this.handleSubmit}>Save Changes</Button>
-          <Button>Cancel</Button>
+          <Button primary onClick={this.handleSubmit} disabled={this.state.disableSubmit}>Save Changes</Button>
+          <Button onClick={this.handleCancel} disabled={this.state.disableCancel}>Cancel</Button>
         </div>
       </div>
     );

--- a/src/fillPullBody.js
+++ b/src/fillPullBody.js
@@ -2,15 +2,20 @@
 
 chrome.runtime.onMessage.addListener(function(request){
   const prBodyElement = document.getElementById('pull_request_body');
-  if(request.fillPR && prBodyElement){
+  if(prBodyElement){
     chrome.storage.sync.get('prTemplate', function({ prTemplate }){
-      if(!prBodyElement.value.includes(prTemplate)){
-        if(prBodyElement.value){
-          prBodyElement.value += '\n';
+      if(request.fillPR){
+        if(!prBodyElement.value.includes(prTemplate)){
+          if(prBodyElement.value){
+            prBodyElement.value += '\n';
+          }
+          prBodyElement.value = prBodyElement.value + prTemplate;
+        } else {
+          prBodyElement.value = prBodyElement.value.replace(prTemplate, '');
         }
-        prBodyElement.value = prBodyElement.value + prTemplate;
-      } else {
-        prBodyElement.value = prBodyElement.value.replace(prTemplate, '');
+      }
+      if(request.replaceTemplate){
+        prBodyElement.value = prBodyElement.value.replace(request.replaceTemplate, prTemplate);
       }
     });
   }


### PR DESCRIPTION
#### What's this PR do?

Load and cancel buttons should load a new template and revert changes in the url and template fields. Cancel should be enabled and disabled based on whether either url or template match the saved version. Save should be enabled and disabled based on whether whether the template matches the saved version. On save, the new template should replace the old template in any open pr tabs. The background page should also first check if a saved template exists, then whether a saved url exists before reverting to defaults on reloading the plugin.
#### Where should the reviewer start?

Most of the changes are contained in the template-tab.js file. Those The save button sends a new message to the fillPullBody.js file, and the background page has a new initial step in checking data.
#### How should this be manually tested?

Try different combinations of changing and canceling changes to the template and url. Check that those changes persist. Try to save a new template and have it replace an old version in an open PR tab. Try saving only a template with a blank url and visa versa.
#### Any background context you want to provide?

The disabling and enabling the upload button added too much complexity for what I thought was little gain. Let me know if you disagree.
#### What are the relevant tickets?

closes #16 
closes #20 
