### PR TITLE
Rest error

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -24,8 +24,8 @@
     "open_in_tab": true
   },
   "permissions": [
-    "http://cdn.rawgit.com/",
-    "http://rawgit.com/",
+    "http://*/",
+    "https://*/",
     "tabs",
     "storage"
   ],

--- a/src/background.js
+++ b/src/background.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const getContent = require('./getContent');
+const getContent = require('./lib/getContent');
 
 chrome.storage.sync.get(['templateUrl', 'prTemplate', 'autoFill'], function({templateUrl, prTemplate, autoFill}){
   if(!prTemplate){

--- a/src/components/template-tab.js
+++ b/src/components/template-tab.js
@@ -85,7 +85,8 @@ class TemplateTab extends React.Component {
       deltaUrl: this.state.templateUrl,
       deltaTemplate: this.state.prTemplate,
       disableCancel: true,
-      disableSubmit: true
+      disableSubmit: true,
+      errorMessage: ''
     });
   }
   handleSubmit(){
@@ -95,7 +96,8 @@ class TemplateTab extends React.Component {
       templateUrl: deltaUrl,
       prTemplate: deltaTemplate,
       disableCancel: true,
-      disableSubmit: true
+      disableSubmit: true,
+      errorMessage: ''
     });
 
     chrome.storage.sync.set({

--- a/src/components/template-tab.js
+++ b/src/components/template-tab.js
@@ -59,8 +59,14 @@ class TemplateTab extends React.Component {
         }
       })
       .otherwise((err)=>{
+        let errorMessage = err.error;
+
+        if(err.status && err.status.text){
+          errorMessage = err.status.text;
+        }
+
         this.setState({
-          errorMessage: err.status.text
+          errorMessage: errorMessage
         });
       });
   }

--- a/src/components/template-tab.js
+++ b/src/components/template-tab.js
@@ -1,8 +1,9 @@
 'use strict';
 
 const _ = require('lodash');
-const rest = require('rest');
 const React = require('react');
+
+const client = require('../lib/client');
 
 const Button = require('../primed/button');
 
@@ -15,7 +16,8 @@ class TemplateTab extends React.Component {
       prTemplate: '',
       deltaTemplate: '',
       disableCancel: true,
-      disableSubmit: true
+      disableSubmit: true,
+      errorMessage: ''
     };
     this.handleTemplateChange = this.handleTemplateChange.bind(this);
     this.handleLoad = this.handleLoad.bind(this);
@@ -41,10 +43,11 @@ class TemplateTab extends React.Component {
     });
   }
   handleLoad(){
-    rest(this.state.deltaUrl)
+    client(this.state.deltaUrl)
       .then((response)=>{
         this.setState({
-          deltaTemplate: response.entity
+          deltaTemplate: response.entity,
+          errorMessage: ''
         });
         if(response.entity === this.state.prTemplate){
           this.setState({ disableSubmit: true });
@@ -54,6 +57,11 @@ class TemplateTab extends React.Component {
         } else {
           this.setState({ disableSubmit: false });
         }
+      })
+      .otherwise((err)=>{
+        this.setState({
+          errorMessage: err.status.text
+        });
       });
   }
   handleUrlChange(){
@@ -95,11 +103,21 @@ class TemplateTab extends React.Component {
       });
     });
   }
+  renderError(){
+    if(this.state.errorMessage){
+      return (
+        <div className="flash flash-error">
+          {this.state.errorMessage}
+        </div>
+       );
+    }
+  }
   render(){
     const { deltaUrl, deltaTemplate } = this.state;
 
     return (
       <div className="four-fifths column">
+        {this.renderError()}
         <dl className='form'>
           <dt>
             <label htmlFor='template'>Template:</label>

--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -1,0 +1,9 @@
+'use strict';
+
+var rest = require('rest');
+var errorCode = require('rest/interceptor/errorCode');
+
+var client = rest
+  .wrap(errorCode);
+
+module.exports = client;

--- a/src/lib/getContent.js
+++ b/src/lib/getContent.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const rest = require('rest');
+const client = require('./client');
 
 function getContent(){
   chrome.storage.sync.get('templateUrl', function(res){
-    return rest(res.templateUrl)
+    return client(res.templateUrl)
       .then(function(response){
         chrome.storage.sync.set({ prTemplate: response.entity });
       });


### PR DESCRIPTION
#### What's this PR do?

Adds error messages that display if loading a template fails, abstracts the rest client, and allows templates to be loaded from any domain.
#### Where should the reviewer start?

src/lib/client.js is a good first start as it allows you to see why changes in other files were made. After that src/components/template-tab.js is the real meat of the PR.
#### How should this be manually tested?

Pull the branch, build it, load the extension, go to options, try and break the url in various ways(hitting load afterwards) and watch the error messages that are displayed. Finally give a valid template url and watch the error vanish like a ninja.
#### Any background context you want to provide?

I found that the statusCode text was usually much more informative than the error message itself whenever it existed.  Unfortunately it doesn't always so sometimes we have to fall back onto the uglier messages.

I played with placement of the error message on the page, my initial thoughts were to have it at the very bottom where all of the extra whitespace was but I couldn't get that to look natural to me.

Chrome errors are being handled in a separate PR.
#### What are the relevant tickets?
#26
#### Screenshots (if appropriate)

![screen shot 2015-05-20 at 8 37 00 pm](https://cloud.githubusercontent.com/assets/2651110/7741533/a8854f2c-ff34-11e4-9d64-f87c51005020.png)
