### PR TITLE
fix multiple load events

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -25,11 +25,11 @@ chrome.pageAction.onClicked.addListener(function(){
 
 chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab){
   const regexUrl = /https:\/\/github\.com\/.*\/.*\/compare\/..*/;
-  if(regexUrl.test(tab.url) && changeInfo.url){
+  if(regexUrl.test(tab.url)){
     chrome.pageAction.show(tabId);
     chrome.storage.sync.get('autoFill', function(res){
       if(res.autoFill){
-        chrome.tabs.sendMessage(tabId, { fillPR: true });
+        chrome.tabs.sendMessage(tabId, { autoFill: true });
       }
     });
   } else {

--- a/src/background.js
+++ b/src/background.js
@@ -24,8 +24,8 @@ chrome.pageAction.onClicked.addListener(function(){
 });
 
 chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab){
-  const regexUrl = /https:\/\/github\.com\/.*\/.*\/compare\/.*/;
-  if(tab.url.match(regexUrl)){
+  const regexUrl = /https:\/\/github\.com\/.*\/.*\/compare\/..*/;
+  if(regexUrl.test(tab.url) && changeInfo.url){
     chrome.pageAction.show(tabId);
     chrome.storage.sync.get('autoFill', function(res){
       if(res.autoFill){

--- a/src/fill-pull-body.js
+++ b/src/fill-pull-body.js
@@ -1,27 +1,27 @@
 'use strict';
 
 chrome.runtime.onMessage.addListener(function(request){
-  function fill(){
-    const prBodyElement = document.getElementById('pull_request_body');
-    if(prBodyElement){
-      chrome.storage.sync.get('prTemplate', function({ prTemplate }){
-        if(request.fillPR){
-          if(!prBodyElement.value.includes(prTemplate)){
-            if(prBodyElement.value){
-              prBodyElement.value += '\n';
-            }
-            prBodyElement.value = prBodyElement.value + prTemplate;
-          } else {
-            prBodyElement.value = prBodyElement.value.replace(prTemplate, '');
+  const prBodyElement = document.getElementById('pull_request_body');
+  if(prBodyElement){
+    chrome.storage.sync.get('prTemplate', function({ prTemplate }){
+      if(request.fillPR){
+        if(!prBodyElement.value.includes(prTemplate)){
+          if(prBodyElement.value){
+            prBodyElement.value += '\n';
           }
+          prBodyElement.value = prBodyElement.value + prTemplate;
+        } else {
+          prBodyElement.value = prBodyElement.value.replace(prTemplate, '');
         }
-        if(request.replaceTemplate){
-          prBodyElement.value = prBodyElement.value.replace(request.replaceTemplate, prTemplate);
+      }
+      if(request.autoFill){
+        if(!prBodyElement.value){
+          prBodyElement.value = prTemplate;
         }
-      });
-    } else {
-      setTimeout(fill, 500);
-    }
+      }
+      if(request.replaceTemplate){
+        prBodyElement.value = prBodyElement.value.replace(request.replaceTemplate, prTemplate);
+      }
+    });
   }
-  fill();
 });

--- a/src/fill-pull-body.js
+++ b/src/fill-pull-body.js
@@ -1,22 +1,27 @@
 'use strict';
 
 chrome.runtime.onMessage.addListener(function(request){
-  const prBodyElement = document.getElementById('pull_request_body');
-  if(prBodyElement){
-    chrome.storage.sync.get('prTemplate', function({ prTemplate }){
-      if(request.fillPR){
-        if(!prBodyElement.value.includes(prTemplate)){
-          if(prBodyElement.value){
-            prBodyElement.value += '\n';
+  function fill(){
+    const prBodyElement = document.getElementById('pull_request_body');
+    if(prBodyElement){
+      chrome.storage.sync.get('prTemplate', function({ prTemplate }){
+        if(request.fillPR){
+          if(!prBodyElement.value.includes(prTemplate)){
+            if(prBodyElement.value){
+              prBodyElement.value += '\n';
+            }
+            prBodyElement.value = prBodyElement.value + prTemplate;
+          } else {
+            prBodyElement.value = prBodyElement.value.replace(prTemplate, '');
           }
-          prBodyElement.value = prBodyElement.value + prTemplate;
-        } else {
-          prBodyElement.value = prBodyElement.value.replace(prTemplate, '');
         }
-      }
-      if(request.replaceTemplate){
-        prBodyElement.value = prBodyElement.value.replace(request.replaceTemplate, prTemplate);
-      }
-    });
+        if(request.replaceTemplate){
+          prBodyElement.value = prBodyElement.value.replace(request.replaceTemplate, prTemplate);
+        }
+      });
+    } else {
+      setTimeout(fill, 500);
+    }
   }
+  fill();
 });


### PR DESCRIPTION
#### What's this PR do?

This fixes an issue with AutoFill where multiple tab update events due to pushState were filling and then unfiling the PR template text in PR body.
#### Where should the reviewer start?

Most changes occurred in the fill-pull-body file.
#### How should this be manually tested?

Make sure that all autofill behavior works as expected though the various navigation methods of opening a new pull request.
#### Any background context you want to provide?

When a page loads, there should only be one complete event, but since git uses pushState, multiple complete events are generated. From what the tabs.onUpdate API can discern, these complete events are indistinguishable from each other. However, the loading events are distinguishable from each other. One of them contains url data. Background is now listening for that event and firing fill-pull-body. However, since it is a loading event and not a completed, the DOM is not fully loaded at the time the message to fill-pull-body is sent. Thus the recursive check for the pull_request_body element.
I think this is a really brittle fix, but I'm not sure what else to do.
#### Screenshots (if appropriate)

![screen shot 2015-06-05 at 2 57 16 pm](https://cloud.githubusercontent.com/assets/2939614/8016029/3ccc7f24-0b93-11e5-9ffc-0446f68db7f8.png)
